### PR TITLE
Display flashed messages in admin page

### DIFF
--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -8,6 +8,14 @@
 <body>
 <div class="container">
 
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+        {% for category, message in messages %}
+          <div class="alert alert-{{ category }}">{{ message }}</div>
+        {% endfor %}
+      {% endif %}
+    {% endwith %}
+
     <!-- 회의명 -->
     <h1 class="meeting-title" id="meeting-title">{{ meeting_title }}</h1>
 


### PR DESCRIPTION
## Summary
- display flash messages on admin dashboard

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fdb0e2f988333abbc1586f383932d