### PR TITLE
Secure shutdown endpoint

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -747,6 +747,7 @@ def export_logs():
         return redirect(url_for('main.admin_dashboard'))
 
 @bp.route('/shutdown', methods=['POST'])
+@login_required
 def shutdown():
     if not request.environ.get('werkzeug.server.shutdown'):
         return 'Not running with the Werkzeug Server', 500

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -34,3 +34,15 @@ def test_login_success_and_generate_tokens(client):
     rv = client.post("/admin/generate_tokens", data={"count": "1"})
     assert rv.status_code == 200
     assert rv.mimetype == "application/zip"
+
+
+def test_shutdown_requires_login(client):
+    rv = client.post("/shutdown")
+    assert rv.status_code == 302
+    assert "/login" in rv.headers["Location"]
+
+
+def test_shutdown_after_login_returns_500(client):
+    login(client)
+    rv = client.post("/shutdown")
+    assert rv.status_code == 500


### PR DESCRIPTION
## Summary
- restrict `/shutdown` route with `@login_required`
- test that shutdown requires login
- test shutdown failure after login

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fdd58e7008333a16aa928e2e77f6f