### PR TITLE
Update run command in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ export ADMIN_PASSWORD=your_password
 
 ### 애플리케이션 실행
 ```bash
-python -m app
+gunicorn --preload app:app -k gevent -w 2 -b 0.0.0.0:8080
 ```
 
 ## Fly.io 배포

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ export ADMIN_PASSWORD=your_password
 ```
 3. Run the application:
 ```bash
-python -m app
+gunicorn --preload app:app -k gevent -w 2 -b 0.0.0.0:8080
 ```
 
 For Fly.io deployments, store the secrets using `fly secrets set` and ensure a volume is mounted at `/data` for persistent storage.


### PR DESCRIPTION
## Summary
- show how to start server with gunicorn in README
- show how to start server with gunicorn in docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_683fe76f17ec833386246a4822204ec7