### PR TITLE
Ignore build venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ var/
 .DS_Store
 Thumbs.db
 app/log/
+venv-build/


### PR DESCRIPTION
## Summary
- update `.gitignore` to exclude `venv-build/`

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ff0b2692c8333a6e90038c3de7ad7