### PR TITLE
Remove extra WORKDIR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ COPY requirements.txt .
 RUN pip install -r requirements.txt
 
 COPY app/ ./app
-WORKDIR /app/app
 
 ENV PORT=8080
 CMD ["gunicorn", "--preload", "app:app", "-k", "gevent", "-w", "2", "-b", "0.0.0.0:8080"]


### PR DESCRIPTION
## Summary
- remove stray `WORKDIR /app/app` from Dockerfile so the server starts correctly

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$(pwd) pytest -q`
- `gunicorn --preload app:app -k gevent -w 2 -b 0.0.0.0:8080` *(fails without SECRET_KEY/ADMIN_PASSWORD)*
- `export SECRET_KEY=secretkey; export ADMIN_PASSWORD=adminpass; gunicorn --preload app:app -k gevent -w 2 -b 0.0.0.0:8080`

------
https://chatgpt.com/codex/tasks/task_e_683ff0b047ac8333943f6c3286922d48